### PR TITLE
Merge ZMQ publisher to main branch.

### DIFF
--- a/PubSubNetworking_ZMQ.py
+++ b/PubSubNetworking_ZMQ.py
@@ -1,0 +1,84 @@
+"""
+This module implements a publisher/subscriber networking protocol using ZMQ. Its development was motivated by the need to share timestamps between two python programs on different PCs. My current usage is to have the OSL as a publisher of its current log timestamp. A script on a Vicon PC will subscribe to that timestamp to embed sync behavior in a vicon log. 
+
+See the test_sub() and test_pub() methods for example usages. 
+
+Requires pyzmq
+
+Kevin Best, 8/17/2023
+"""
+import zmq
+from NeuroLocoMiddleware.StatProfiler import SSProfile
+
+class Subscriber():
+    def __init__(self, publisher_ip = 'localhost', publisher_port = "5556", 
+                 timeout_ms = 100, topic_filter = '', get_latest_only = True) -> None:
+        """
+        Instantiate a subscriber object. Requires the IP address of the publisher, the port of the publisher, an optional timeout flag, optional topic filter, and a bool to ask for only the latest value if there are more than one in the buffer. 
+        """
+        # Socket to talk to server
+        context = zmq.Context()
+        self.socket = context.socket(zmq.SUB)
+        self.socket.setsockopt_string(zmq.SUBSCRIBE, topic_filter)
+        if get_latest_only:
+            self.socket.setsockopt(zmq.CONFLATE, 1) 
+        self.socket.connect(("tcp://" + publisher_ip + ":%s") % publisher_port)
+        self.timeout_ms = timeout_ms
+        self.encoding =  'UTF-8'
+    
+    def get_message(self) -> (str, str, bool):
+        """
+        Checks for a message from the subscribed topics. If no message is available in the timeout, it'll return blank topic and message. The msg_received flag will also be false. 
+        """
+        msg_received = self.socket.poll(self.timeout_ms)
+        if msg_received == 0:
+            message_decoded = ''
+            topic_decoded = ''
+        else:
+            string = self.socket.recv(zmq.NOBLOCK)
+            topic, message = string.split()
+            topic_decoded = str(topic, self.encoding)
+            message_decoded = str(message, self.encoding)
+        return topic_decoded, message_decoded, msg_received
+
+
+class Publisher():
+    """ 
+    Instantiates a publisher object. Only required input is a port. Any subscriber on the network can subscribe to this topic via the IP address of the publisher. 
+    """
+    def __init__(self, port = "5556") -> None:
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.PUB)
+
+        self.socket.bind("tcp://*:%s" % port)
+
+    @SSProfile("publish").decorate
+    def publish(self, topic, message) -> None:
+        """
+        Publish a message on a specified topic. Note that topic names CANNOT have spaces in them. 
+        """
+        assert " " not in topic, "topic name cannot have spaces!"
+        self.socket.send_string(topic + " " + message)
+
+
+def testSub():
+    """
+    Import this method and run in a thread to test the subscriber behavior. Once you start a publisher, you should see the data parsed. 
+    """
+    sub = Subscriber()
+    while(1):
+        topic, string, event = sub.get_message()
+        if event:
+            print("Topic: " + topic + " String: " + string)
+
+def testPub():
+    """
+    Import this method and run in a thread to see publisher behavior. You should see whatever data you sent here appear in a subscriber. 
+    """
+    pub = Publisher()
+    i = 0
+
+    while(1):
+        pub.publish("Test_Publisher_Topic_1","%d" % i)
+        i+=1
+

--- a/ZMQ_PubSub.py
+++ b/ZMQ_PubSub.py
@@ -1,5 +1,8 @@
 """
-This module implements a publisher/subscriber networking protocol using ZMQ. Its development was motivated by the need to share timestamps between two python programs on different PCs. My current usage is to have the OSL as a publisher of its current log timestamp. A script on a Vicon PC will subscribe to that timestamp to embed sync behavior in a vicon log. 
+This module implements a publisher/subscriber networking protocol using ZMQ. 
+Its development was motivated by the need to share timestamps between two python programs on different PCs. 
+My current usage is to have the OSL as a publisher of its current log timestamp. 
+A script on a Vicon PC will subscribe to that timestamp to embed sync behavior in a vicon log. 
 
 See the test_sub() and test_pub() methods for example usages. 
 
@@ -8,7 +11,6 @@ Requires pyzmq
 Kevin Best, 8/17/2023
 """
 import zmq
-from NeuroLocoMiddleware.StatProfiler import SSProfile
 
 class Subscriber():
     def __init__(self, publisher_ip = 'localhost', publisher_port = "5556", 
@@ -29,6 +31,7 @@ class Subscriber():
     def get_message(self) -> (str, str, bool):
         """
         Checks for a message from the subscribed topics. If no message is available in the timeout, it'll return blank topic and message. The msg_received flag will also be false. 
+        Returns topic, message, msg_received flag
         """
         msg_received = self.socket.poll(self.timeout_ms)
         if msg_received == 0:
@@ -52,7 +55,6 @@ class Publisher():
 
         self.socket.bind("tcp://*:%s" % port)
 
-    @SSProfile("publish").decorate
     def publish(self, topic, message) -> None:
         """
         Publish a message on a specified topic. Note that topic names CANNOT have spaces in them. 


### PR DESCRIPTION
This module allows a python script to publish current values to the network. This can be helpful when you have multiple computers running and you want to communicate latest values between them. For example: 

Example usage
```
from NeuroLocoMiddleware.PubSubNetworking_ZMQ import Publisher

for t in loop:
    publisher.publish(topic = 'OSLV2.loopTimestamp',message="%6.2f" % t)
    publisher.publish(topic = 'OSLV2.filename', message = viconLogName)

```