### PR TITLE
Removed float restriction in variable updater

### DIFF
--- a/VariableUpdater.py
+++ b/VariableUpdater.py
@@ -4,20 +4,20 @@ import time
 
 class VariableUpdater:
     """
-    This class has a floating value called 'variable' that can be updated by a 
+    This class has a value called 'variable' that can be updated by a 
     separate process. The class listens for updates to the variable and updates
     it accordingly. Multiple instances of this class can be created to listen
     for updates to different variables as long as they have different 
     subscription ports.
     """
-    def __init__(self, initial_value:float, sub_port:str="5551", 
+    def __init__(self, initial_value, sub_port:str="5551", 
                        update_interval:int=1):
         """
         Initialize the VariableUpdater object with the initial value of the
         variable and the subscription port to listen for updates.   
 
         Args:
-            initial_value (float): The initial value of the variable
+            initial_value: The initial value of the variable (can be any Python object)
             sub_port (str, optional): The subscription port to listen for updates.
                 Defaults to "5551".
             update_interval (int, optional): The interval at which to check for
@@ -44,9 +44,8 @@ class VariableUpdater:
             try:
                 # Receive a Python object
                 message = self.subscriber.recv_pyobj(flags=zmq.NOBLOCK)  
-                # Ensure it's a float
-                if isinstance(message, float):  
-                    self.variable = message
+                # Update the variable with the received object
+                self.variable = message
             # If we don't receive a message, continue loop
             except zmq.Again:
                 pass 
@@ -57,6 +56,10 @@ def send_update(new_value, pub_port="5551"):
     """
     Send an update to the variable to the subscriber listening on the specified
     port.
+
+    Args:
+        new_value: The new value to send (can be any Python object)
+        pub_port (str, optional): The port to publish the update on. Defaults to "5551".
     """
     # Create a ZeroMQ context to generate a publish socket
     context = zmq.Context()

--- a/test/example_VariableUpdater_receive.py
+++ b/test/example_VariableUpdater_receive.py
@@ -1,6 +1,11 @@
+import sys
+import os
 import time
 
-from udpate_vars import VariableUpdater
+# Add the parent folder to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from VariableUpdater import VariableUpdater
 
 # Create a VariableUpdater object with an initial value of 0.0
 updater = VariableUpdater(initial_value=0.0)
@@ -9,4 +14,4 @@ updater = VariableUpdater(initial_value=0.0)
 while True:
     print(f"Current variable value: {updater.variable}")
     # Simulate work
-    time.sleep(0.3)  
+    time.sleep(0.3)

--- a/test/example_VariableUpdater_send.py
+++ b/test/example_VariableUpdater_send.py
@@ -1,6 +1,29 @@
-from udpate_vars import send_update
+import sys
+import os
 
-# Prompt the user for a new value for the variable
-new_value = float(input("Enter new value for the variable: "))
-# Send the new value to the subscriber
-send_update(new_value)
+# Add the parent folder to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from VariableUpdater import send_update
+
+
+def test_float():
+    # Prompt the user for a new value for the variable
+    new_value = float(input("Enter new value for the variable: "))
+    # Send the new value to the subscriber
+    send_update(new_value)  
+
+def test_dictionary():
+    dictionary = {
+        "key1": 4,
+        "key2": [1, 2, 3],
+        "key3": "test",
+    }
+    # Send the dictionary to the subscriber
+    send_update(dictionary)
+
+if __name__ == "__main__":
+    # Test sending a float value
+    # test_float()
+    # Test sending a dictionary
+    test_dictionary()


### PR DESCRIPTION
Code now works for arbitrary python types. I updated the two test scripts as well, showing that it works for both a float and a dictionary. Should work for any other python type too. 

![image](https://github.com/user-attachments/assets/4dd17859-4bc9-4ec6-98b5-89aaa078b8b7)
